### PR TITLE
Update of cap_door_contr (Entities) and give utility to cap_console

### DIFF
--- a/lua/entities/cap_console.lua
+++ b/lua/entities/cap_console.lua
@@ -25,21 +25,42 @@ function ENT:Initialize()
 	self:SetMoveType(MOVETYPE_VPHYSICS);
 	self:SetSolid(SOLID_VPHYSICS);
 	self:SetUseType(SIMPLE_USE);
+
+	self.Pressed = false
+	self:CreateWireOutputs("Active");
 end
 
 function ENT:Think()
-	local ply = StarGate.FindPlayer(self:GetPos(), 400);
+	//local ply = StarGate.FindPlayer(self:GetPos(), 400);
 
-	if (ply and not self.Light) then
+	/*if (ply and not self.Light) then
 		self.Light = true;
 		self:SetSkin(1);
 	elseif (not ply and self.Light) then
 		self.Light = false;
 		self:SetSkin(0);
-	end
+	end*/
 
-	self:NextThink(CurTime()+0.5);
+	//self:NextThink(CurTime()+0.5);
 	return true
+end
+
+function ENT:Use()
+	self:PressConsole();
+end
+
+function ENT:PressConsole()
+	if(not self.Pressed) then
+		self.Pressed = true
+		self:SetSkin(1)
+		self.Light=true
+		self:SetWire("Active",1);
+	else
+		self.Pressed = false
+		self:SetSkin(0)
+		self.Light=true
+		self:SetWire("Active",0);
+	end
 end
 
 end

--- a/lua/entities/cap_console.lua
+++ b/lua/entities/cap_console.lua
@@ -26,7 +26,8 @@ function ENT:Initialize()
 	self:SetSolid(SOLID_VPHYSICS);
 	self:SetUseType(SIMPLE_USE);
 
-	self.Pressed = false
+	self.Pressed = false;
+	self:CreateWireInputs("Pressed");
 	self:CreateWireOutputs("Active");
 end
 
@@ -45,20 +46,28 @@ function ENT:Think()
 	return true
 end
 
+function ENT:TriggerInput(variable, value)
+	if (variable == "Pressed") then
+		if(value<=0)then
+			self:PressConsole();
+		end
+	end
+end
+
 function ENT:Use()
 	self:PressConsole();
 end
 
 function ENT:PressConsole()
 	if(not self.Pressed) then
-		self.Pressed = true
-		self:SetSkin(1)
-		self.Light=true
+		self.Pressed = true;
+		self:SetSkin(1);
+		self.Light=true;
 		self:SetWire("Active",1);
 	else
-		self.Pressed = false
-		self:SetSkin(0)
-		self.Light=true
+		self.Pressed = false;
+		self:SetSkin(0);
+		self.Light=true;
 		self:SetWire("Active",0);
 	end
 end

--- a/lua/entities/cap_doors_contr.lua
+++ b/lua/entities/cap_doors_contr.lua
@@ -29,7 +29,9 @@ ENT.Sounds={
 	PressDest=Sound("door/dest_door_button.wav"),
 	PressAtl=Sound("door/atlantis_door_chime.wav"),
 	PressGoa=Sound("button/ring_button1.mp3"),
+	PressGoa2=Sound("button/ring_button2.mp3"),
 	PressOri=Sound("button/ancient_button1.wav"),
+	PressOri2=Sound("button/ancient_button2.wav"),
 }
 
 -----------------------------------INIT----------------------------------
@@ -77,8 +79,20 @@ function ENT:BressButton()
 	end);
 
 	if (self.TypeS == 1) then self.Entity:EmitSound(self.Sounds.PressDest,100,math.random(90,110));
-	elseif (self.TypeS == 3) then self.Entity:EmitSound(self.Sounds.PressGoa,100,math.random(90,110));
-	elseif (self.TypeS == 4 or self.TypeS == 5) then self.Entity:EmitSound(self.Sounds.PressOri,100,math.random(90,110));
+	elseif (self.TypeS == 3) then
+		local SoundToPlay = math.random(0,1)
+		if(SoundToPlay==1) then
+			self.Entity:EmitSound(self.Sounds.PressGoa,100,math.random(90,110));
+		else
+			self.Entity:EmitSound(self.Sounds.PressGoa2,100,math.random(90,110));
+		end
+	elseif(self.TypeS == 4 or self.TypeS == 5) then
+		local SoundToPlay = math.random(0,1)
+		if(SoundToPlay==1) then
+			self.Entity:EmitSound(self.Sounds.PressOri,100,math.random(90,110));
+		else
+			self.Entity:EmitSound(self.Sounds.PressOri2,100,math.random(90,110));
+		end
 	else self.Entity:EmitSound(self.Sounds.PressAtl,100,math.random(90,110)); end
 
 	if (self.Atlantis and IsValid(self.AtlTP) and self.AtlTP.Busy) then return end

--- a/lua/stargate/shared/misc.lua
+++ b/lua/stargate/shared/misc.lua
@@ -35,11 +35,17 @@ end
 list.Set( "ButtonModels", "models/Iziraider/destinybutton/destinybutton.mdl", {} )
 list.Set( "ButtonModels", "models/Boba_Fett/props/buttons/atlantis_button.mdl", {} )
 list.Set( "ButtonModels", "models/Iziraider/artifacts/asgard_stone.mdl", {} )
+list.Set( "ButtonModels", "models/Madman07/ring_panel/goauld_panel.mdl", {Angle=Angle(270,0,0),Position=Vector(0,0,-12)} )
+list.Set( "ButtonModels", "models/Zsdaniel/ori-ringpanel/panel.mdl", {Angle=Angle(270,0,0),Position=Vector(0,0,-5)} )
+list.Set( "ButtonModels", "models/Madman07/ring_panel/ancient/panel.mdl", {Angle=Angle(270,0,0),Position=Vector(0,0,-10)} )
 
 -- Add wire buttons
 list.Set( "Wire_button_Models", "models/Iziraider/destinybutton/destinybutton.mdl", {} )
 list.Set( "Wire_button_Models", "models/Boba_Fett/props/buttons/atlantis_button.mdl", {} )
 list.Set( "Wire_button_Models", "models/Iziraider/artifacts/asgard_stone.mdl", {} )
+list.Set( "Wire_button_Models", "models/Madman07/ring_panel/goauld_panel.mdl", {Angle=Angle(270,0,0),Position=Vector(0,0,-12)} )
+list.Set( "Wire_button_Models", "models/Zsdaniel/ori-ringpanel/panel.mdl", {Angle=Angle(270,0,0),Position=Vector(0,0,-5)} )
+list.Set( "Wire_button_Models", "models/Madman07/ring_panel/ancient/panel.mdl", {Angle=Angle(270,0,0),Position=Vector(0,0,-10)} )
 
 -- Player models and NPCs
 if (StarGate.CheckModule("npc")) then

--- a/lua/weapons/gmod_tool/stools/janus_door.lua
+++ b/lua/weapons/gmod_tool/stools/janus_door.lua
@@ -36,7 +36,7 @@ if (CLIENT) then
 
 	function TOOL:BuildCPanel()
 		self:AddControl("Header",   {Text = "#Tool_janus_door_name", Description = "#Tool_janus_door_desc"});
-		self:AddControl("CheckBox", {Label = "Reversed (Starts invisible, becomes solid)", Command = "janus_door_reversed"});
+		self:AddControl("CheckBox", {Label = "Reversed (Starts no solid, becomes solid)", Command = "janus_door_reversed"});
 		self:AddControl("CheckBox", {Label = "Toggle Active", Command = "janus_door_toggle"});
 		self:AddControl("Numpad",   {Label = "Button", ButtonSize = "22", Command = "janus_door_key"});
 	end


### PR DESCRIPTION
I have set a random sound for Ori, Ancient and Goauld doors controller
I have create Wire Output to cap_console (Active). It toggle to active when a Player press Use key (Maybe add an Utility).
I have create a Wire Input to cap_console (Pressed) who simulate a Player press key

If have search for add sounds but I did not find it on internet.

The new wire Buttons doesn't have the good Angle, but I have try to change like in cap_doors_contr but it doesn't work.

Small correction for the Janus Door, it was not Invisible but no solid (Why don't active that ?)