### PR TITLE
Cap Destiny Bridge Door Code and Fix for Wire Input For Stool: Shield Generator

### DIFF
--- a/lua/entities/cap_doors_frame.lua
+++ b/lua/entities/cap_doors_frame.lua
@@ -28,6 +28,8 @@ ENT.Sounds={
 	Lock=Sound("door/dest_door_lock.wav"),
 	AtlOpen=Sound("door/atlantis_door_open.wav"),
 	AtlClose=Sound("door/atlantis_door_close.wav"),
+	DestBridgeOpen=Sound("cryptalchemy_sounds/destiny/bridge_door/bridge_door_open.wav"),
+	DestBridgeClose=Sound("cryptalchemy_sounds/destiny/bridge_door/bridge_door_close.wav"),
 }
 
 -----------------------------------INIT----------------------------------
@@ -70,6 +72,9 @@ function ENT:SoundType(t)
 	if (t == 1) then
 		self.Door.OpenSound = self.Sounds.DestOpen;
 		self.Door.CloseSound = self.Sounds.DestClose;
+	elseif (t == 9000) then
+		self.Door.OpenSound = self.Sounds.DestBridgeOpen;
+		self.Door.CloseSound = self.Sounds.DestBridgeClose;
 	else
 		self.Door.OpenSound = self.Sounds.AtlOpen;
 		self.Door.CloseSound = self.Sounds.AtlClose;

--- a/lua/entities/shield_generator.lua
+++ b/lua/entities/shield_generator.lua
@@ -108,7 +108,7 @@ function ENT:Status(b,nosound)
 					self.Shield = e;
 					self:ShowOutput(true);
 					if(not nosound) then
-						if(self.SndDisable==1) then
+						if(self.SndDisable==0) then
 							self:EmitSound(self.Sounds.Engage,90,math.random(90,110));
 						end
 					end
@@ -124,14 +124,14 @@ function ENT:Status(b,nosound)
 			self.Shield = nil;
 			self:ShowOutput(false);
 			if(not nosound and not self.Depleted) then
-				if(self.SndDisable==1) then
+				if(self.SndDisable==0) then
 					self:EmitSound(self.Sounds.Disengage,90,math.random(90,110));
 				end
 			end
 		end
 		return;
 	end
-	if(self.SndDisable==1) then
+	if(self.SndDisable==0) then
 		-- Fail animation
 		self:EmitSound(self.Sounds.Fail[1],90,math.random(90,110));
 		self:EmitSound(self.Sounds.Fail[2],90,math.random(90,110));
@@ -147,7 +147,7 @@ function ENT:Think()
 		if(self.Strength >= math.Clamp(self.RestoreThresold/self.StrengthMultiplier[2],3,40)) then
 			self.Depleted = nil;
 			if(enabled) then
-				if(self.SndDisable==1) then
+				if(self.SndDisable==0) then
 					self:EmitSound(self.Sounds.Engage,90,math.random(90,110));
 				end
 				-- Add new entities to the shield, which "entered the shield" while it was offline!

--- a/lua/weapons/gmod_tool/stools/capdoors.lua
+++ b/lua/weapons/gmod_tool/stools/capdoors.lua
@@ -10,11 +10,12 @@ TOOL.Name=SGLanguage.GetMessage("stool_door");
 TOOL.ClientConVar["autoweld"] = 1;
 TOOL.ClientConVar["toggle"] = 3;
 TOOL.ClientConVar["diff_text"] = 0;
-TOOL.ClientConVar["model"] = "models/madman07/doors/dest_door.mdl";
+TOOL.ClientConVar["model"] = "models/cryptalchemy_models/destiny/bridge_door/bridge_door.mdl";
 TOOL.ClientConVar["doormodel"] = "";
 
 TOOL.List = "DoorsModels";
 list.Set(TOOL.List,"models/madman07/doors/dest_door.mdl",{});
+list.Set(TOOL.List,"models/cryptalchemy_models/destiny/bridge_door/bridge_door.mdl",{});
 list.Set(TOOL.List,"models/madman07/doors/atl_door1.mdl",{});
 list.Set(TOOL.List,"models/madman07/doors/atl_door2.mdl",{});
 list.Set(TOOL.List,"models/madman07/doors/atl_door3.mdl",{});
@@ -39,6 +40,7 @@ function TOOL:LeftClick(t)
 	local diff_text = util.tobool(self:GetClientNumber("diff_text"));
 	local doormodel = model;
 	if (model == "models/madman07/doors/dest_door.mdl") then model = "models/madman07/doors/dest_frame.mdl";
+	elseif (model == "models/cryptalchemy_models/destiny/bridge_door/bridge_door.mdl") then model = "models/cryptalchemy_models/destiny/bridge_door/bridge_door_frame.mdl";
 	elseif (model == "models/madman07/doors/atl_door3.mdl") then model = "models/gmod4phun/props/atlantis_door_frame_2.mdl"; -- New door and frame
 	else model = "models/madman07/doors/atl_frame.mdl"; end
 
@@ -55,6 +57,7 @@ function TOOL:LeftClick(t)
 		if diff_text then e:SetMaterial("madman07/doors/atlwall_red"); end
 	end
 	if (model == "models/madman07/doors/dest_frame.mdl") then e:SoundType(1);
+	elseif (model == "models/cryptalchemy_models/destiny/bridge_door/bridge_door_frame.mdl") then e:SoundType(9000);
 	else e:SoundType(2); end
 
 	return true;


### PR DESCRIPTION
Cap Destiny Bridge Door:
Design and Creation By CryptAlchemy
Posted on
http://www.sg-carterpack.com/forums/topic/cap-destiny-bridge-door/#post-6892.
Im just making the pull request and wont take credit for the work

Fix for the wire input for the stool shield generator:
Error:
Sound would be disabled without wire input and enabled with wire input.
Fix: Sound is now enabled by default and disabled with wire input
by KvasirSG