### PR TITLE
Hide Viewmodel SGC Chevron 7 Model

### DIFF
--- a/lua/entities/sgc_monitor/screens/chevron7.lua
+++ b/lua/entities/sgc_monitor/screens/chevron7.lua
@@ -52,6 +52,7 @@ else
       w = 510,
       h = 382,
       fov = 70,
+      drawviewmodel = false
      } )
    else
      draw.SimpleText("OFFLINE", "Marlett_61", 247, 190, Color(200,0,0,math.abs(math.sin(CurTime()*math.pi/2))*255), TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER)


### PR DESCRIPTION
If this is not set some weapons actually draw their viewmodel over that. (Exspecially CW2.0) It's an easy fix and probably should have been done from the beginning