### PR TITLE
Re-enabled "Atlantis Type" property

### DIFF
--- a/lua/entities/stargate_atlantis/shared.lua
+++ b/lua/entities/stargate_atlantis/shared.lua
@@ -142,7 +142,7 @@ properties.Add( "Stargate.Atl.AtlType.Off",
 
 });
 
-properties.Add( "Stargate.Atl.AtlType.On",
+properties.Add( "Stargate.Atl.AltSlowDial.On",
 {
 	MenuLabel	=	SGLanguage.GetMessage("stargate_c_tool_22"),
 	Order		=	-130,
@@ -174,7 +174,7 @@ properties.Add( "Stargate.Atl.AtlType.On",
 
 });
 
-properties.Add( "Stargate.Atl.AtlType.Off",
+properties.Add( "Stargate.Atl.AltSlowDial.Off",
 {
 	MenuLabel	=	SGLanguage.GetMessage("stargate_c_tool_22d"),
 	Order		=	-130,


### PR DESCRIPTION
The "Alternate slow dial" context menu property had the same name as the "Atlantis Type" property, disabling the latter. This renames the slow dial property, re-enabling the Atlantis type property.