### PR TITLE
Nox Hands can bypass an iris if allowed in cap config

### DIFF
--- a/lua/data/language/en/stargate_settings.lua
+++ b/lua/data/language/en/stargate_settings.lua
@@ -254,6 +254,11 @@ sg_sets[stargate][res_trans_interval][desc] = Resource transfer cycle inteval in
 sg_sets[stargate][res_classes] = Allowed resource classes
 sg_sets[stargate][res_classes][desc] = Allowed resource classes to transfer, separate by comma, keep empty to allow any resources\nexample usage: water,oxygen,heavy water
 
+// Iris
+sg_sets[iris] = Iris
+sg_sets[iris][nox_bypass] = Nox Hands Bypass
+sg_sets[iris][nox_bypass][desc] = Allow anyone with Nox Hands equipped to bypass an iris
+
 // Stargate gatespawner config
 sg_sets[gatespawner] = Gatespawner
 sg_sets[gatespawner][spawn_iris] = Spawn iris on gatespawner gates

--- a/lua/data/stargate/config.lua
+++ b/lua/data/stargate/config.lua
@@ -98,6 +98,11 @@ res_trans_interval = 0.1
 # allowed resources to transfer, separate by comma, keep empty to allow any resources, example usage: water,oxygen,heavy water
 res_classes = 
 
+#### Stargate Iris config
+[iris]
+# Allow pass through with Nox Hands
+nox_bypass=true
+
 #### Stargate gatespawner config
 [gatespawner]
 # Allow spawn iris on gatespawner gates by players

--- a/lua/entities/event_horizon/init.lua
+++ b/lua/entities/event_horizon/init.lua
@@ -787,7 +787,10 @@ function ENT:StartTouchPlayersNPCs(e,ignore)
 		if(not block) then
 			target_gate = self.Target:GetParent();
 			if(IsValid(target_gate) and target_gate.IsStargate) then
-				block = target_gate:IsBlocked();
+				-- Allow player with Nox hands to pass through any iris if enabled in config
+				if (not StarGate.CFG:Get("iris", "nox_bypass", false) or (not e:IsPlayer() or e:GetActiveWeapon():GetClass() ~= "nox_hands")) then
+					block = target_gate:IsBlocked();
+				end
 			end
 			if (self:BlockedCFD(target_gate,e)) then block = false; bcfd = true; end
 		end


### PR DESCRIPTION
Nox & Tollans can pass through SGC iris, since creating a weapon only for this seem unrevelant, I set it to nox hands SWEP
Enabled by default in config since on most servers, this SWEP is disabled for non-admin by default