### PR TITLE
added some GateSpawner lua's

### DIFF
--- a/lua/data/gatespawner_group_maps/gm_construct_13_beta.lua
+++ b/lua/data/gatespawner_group_maps/gm_construct_13_beta.lua
@@ -1,0 +1,175 @@
+[gatespawner]
+version = 3 Group
+
+
+[stargate]
+classname=stargate_atlantis
+position=1187.316284 6297.323730 108.275398
+angles=0.000 -90.500 0.000
+address=WATERS
+group=M@
+name=Waterside
+private=false
+locale=false
+[stargate]
+classname=stargate_sg1
+position=-5187.546875 -1479.059814 -53.968800
+angles=0.000 0.800 -0.000
+address=DARKCH
+group=M@
+name=Dark Room
+private=false
+locale=false
+[stargate]
+classname=stargate_sg1
+position=-2323.649170 -3028.020996 2938.031250
+angles=0.000 90.340 0.000
+address=SKYCRA
+group=M@
+name=Skyscraper
+private=false
+locale=true
+[stargate]
+classname=stargate_tollan_hd
+position=-4178.337891 5340.491699 2254.476318
+angles=-0.025 -179.990 0.004
+address=5ZO4P0
+group=M@
+name=Admin area
+private=false
+locale=true
+[stargate]
+classname=stargate_sg1_hd
+position=-1899.912598 968.977722 -381.580017
+angles=-0.008 -88.837 0.002
+address=0TO2WS
+group=M@
+name=Underground
+private=false
+locale=true
+[stargate]
+classname=stargate_tollan_hd
+position=-2075.965576 -4566.186035 -165.968750
+angles=0.000 89.833 0.000
+address=Q2S9CI
+group=M@
+name=White Room
+private=false
+locale=true
+[stargate]
+classname=stargate_atlantis_hd
+position=2503.974121 5705.085938 -77.968750
+angles=0.000 -90.857 0.000
+address=60J7QX
+group=M@
+name=Under Water Base
+private=false
+locale=true
+[stargate]
+classname=stargate_sg1_hd
+position=473.407806 72.473824 -59.052963
+angles=0.000 357.953 0.000
+address=UX9CFG
+group=M@
+name=Spawn
+private=false
+locale=true
+[dhd]
+classname=dhd_atlantis
+position=1355.333984 6149.300293 -46.768696
+angles=15.000 -52.000 0.000
+destroyed=false
+[dhd]
+classname=dhd_sg1
+position=-5064.142578 -1302.962158 -158.768799
+angles=15.000 20.600 -0.000
+destroyed=false
+[dhd]
+classname=dhd_sg1
+position=-2493.044189 -2871.743164 2832.231201
+angles=15.000 89.020 0.000
+destroyed=false
+[dhd]
+classname=dhd_universe
+position=-4230.210449 5187.031738 2113.231201
+angles=15.000 182.197 0.000
+destroyed=false
+[dhd]
+classname=dhd_sg1_hd
+position=-1705.113037 905.611938 -510.331757
+angles=15.000 -89.591 0.000
+destroyed=false
+[dhd]
+classname=dhd_universe
+position=-2225.179443 -4517.650391 -270.768738
+angles=15.000 88.645 0.000
+destroyed=false
+[dhd]
+classname=dhd_atlantis_hd
+position=2660.383789 5652.877930 -182.768753
+angles=15.000 269.779 0.000
+destroyed=false
+[dhd]
+classname=dhd_sg1_hd
+position=520.791504 239.550995 -162.889786
+angles=15.000 -0.991 0.000
+destroyed=false
+[ring_panel]
+classname=ring_panel_goauld
+position=-3232.000000 -1697.268188 98.031303
+angles=0.000 0.580 -0.000
+[ring_panel]
+classname=ring_panel_goauld
+position=908.775330 -1023.502380 -94.419701
+angles=0.000 90.015 -0.294
+[ring_panel]
+classname=ring_panel_goauld
+position=-2063.573486 -2559.780762 -205.968796
+angles=0.000 89.020 0.000
+[ring_panel]
+classname=ring_panel_goauld
+position=-4944.483398 5356.520996 -53.150200
+angles=0.000 179.560 0.000
+[ring_panel]
+classname=ring_panel_goauld
+position=1847.504761 -1600.170288 1181.507324
+angles=-0.000 179.998 -0.653
+[ring_base]
+classname=ring_base_ancient
+position=908.872986 -916.719971 -143.618301
+angles=0.001 94.437 -0.010
+address=1
+[ring_base]
+classname=ring_base_ancient
+position=-3120.313232 -1701.118774 48.031300
+angles=0.000 91.440 -0.000
+address=3
+[ring_base]
+classname=ring_base_ancient
+position=-2065.189941 -2474.619385 15.670500
+angles=0.003 71.669 -179.998
+address=2
+[ring_base]
+classname=ring_base_ancient
+position=-5048.918945 5357.426758 -95.504700
+angles=0.001 -179.992 -0.003
+address=4
+[ring_base]
+classname=ring_base_goauld
+position=1767.558472 -1601.439941 1136.438354
+angles=-0.001 173.831 0.001
+address=5
+[ramp]
+classname=ramp
+position=1187.316284 6297.323730 -31.724600
+angles=0.000 -90.500 0.000
+model=models/zsdaniel/ramp/ramp.mdl
+[ramp]
+classname=ramp
+position=-4358.393066 5340.453125 2128.555420
+angles=-0.025 -179.990 0.004
+model=models/boba_fett/ramps/ramp11.mdl
+[ramp]
+classname=goauld_ramp
+position=-1899.906372 968.957520 -527.580017
+angles=-0.008 -88.837 0.002

--- a/lua/data/gatespawner_group_maps/gm_excess_construct_13.lua
+++ b/lua/data/gatespawner_group_maps/gm_excess_construct_13.lua
@@ -1,0 +1,190 @@
+[gatespawner]
+version = 3 Group
+
+
+[stargate]
+classname=stargate_atlantis
+position=2413.541016 4106.612305 145.031250
+angles=0.000 -90.058 0.000
+address=SAWNRE
+group=P@
+name=Spawn
+private=false
+locale=false
+[stargate]
+classname=stargate_sg1
+position=-1086.741333 -11171.209961 82.031250
+angles=0.000 -90.318 0.000
+address=WATER0
+group=M@
+name=Water
+private=false
+locale=false
+[stargate]
+classname=stargate_universe
+position=11263.932617 -9664.975586 666.031250
+angles=0.000 -89.991 0.000
+address=TANGLE
+group=U@!
+name=Tangle
+private=false
+locale=false
+[stargate]
+classname=stargate_universe
+position=-13839.953125 -4987.922363 172.275406
+angles=-0.000 44.368 0.000
+address=DESRTA
+group=U@!
+name=Desert
+private=false
+locale=false
+[stargate]
+classname=stargate_sg1
+position=-5983.814453 -4609.833496 548.031250
+angles=0.000 -0.266 0.000
+address=HIDENR
+group=M@
+name=Hidden room
+private=true
+locale=false
+[stargate]
+classname=stargate_sg1
+position=-3557.888916 2095.368408 762.031250
+angles=0.000 -0.103 0.000
+address=COPLEX
+group=M@
+name=Complex 1
+private=false
+locale=false
+[stargate]
+classname=stargate_sg1
+position=-5955.070801 11049.142578 490.031250
+angles=0.000 -1.252 0.000
+address=GAREN1
+group=M@
+name=Garage 1
+private=false
+locale=false
+[stargate]
+classname=stargate_sg1
+position=4467.729004 10350.561523 202.031250
+angles=0.000 179.715 0.000
+address=GAREN2
+group=M@
+name=Garage 2
+private=false
+locale=false
+[stargate]
+classname=stargate_atlantis
+position=-3384.357666 3372.245117 538.531250
+angles=0.000 89.608 0.000
+address=COMLEX
+group=P@
+name=Complex 2
+private=false
+locale=false
+[stargate]
+classname=stargate_atlantis
+position=10172.758789 1199.981934 90.031250
+angles=0.000 270.636 0.000
+address=GAREN3
+group=P@
+name=Garage 3
+private=false
+locale=false
+[stargate]
+classname=stargate_atlantis
+position=-7598.346191 -1020.338074 490.031250
+angles=0.000 359.159 0.000
+address=GAREN4
+group=P@
+name=garage 4
+private=false
+locale=false
+[stargate]
+classname=stargate_sg1
+position=10066.728516 9216.745117 -9125.968750
+angles=0.000 -0.205 0.000
+address=OASIRE
+group=M@
+name=Oasis
+private=true
+locale=false
+[dhd]
+classname=dhd_atlantis
+position=2157.581543 3879.656738 -14.768750
+angles=15.000 252.102 0.000
+destroyed=false
+[dhd]
+classname=dhd_sg1
+position=-1086.917358 -11830.138672 -22.768749
+angles=15.000 -90.072 0.000
+destroyed=false
+[dhd]
+classname=dhd_universe
+position=11458.352539 -9702.620117 561.231262
+angles=15.000 -89.991 -0.000
+destroyed=false
+[dhd]
+classname=dhd_universe
+position=-13670.240234 -4993.522949 17.231255
+angles=15.000 16.379 -0.000
+destroyed=false
+[dhd]
+classname=dhd_sg1
+position=-5637.783203 -4488.911133 385.231262
+angles=15.000 33.207 0.000
+destroyed=false
+[dhd]
+classname=dhd_sg1
+position=-3239.105957 1906.526123 657.231262
+angles=15.000 -0.512 -0.000
+destroyed=false
+[dhd]
+classname=dhd_sg1
+position=-5539.004883 10926.585938 385.231262
+angles=15.000 -3.707 0.000
+destroyed=false
+[dhd]
+classname=dhd_sg1
+position=4150.478516 10598.260742 97.231247
+angles=15.000 178.242 -0.000
+destroyed=false
+[dhd]
+classname=dhd_atlantis
+position=9985.429688 1156.426025 -14.768750
+angles=15.000 -132.657 -0.000
+destroyed=false
+[dhd]
+classname=dhd_atlantis
+position=-7570.587891 -1200.378540 385.231262
+angles=15.000 328.060 0.000
+destroyed=false
+[mobile_dhd]
+classname=mobile_dhd
+position=10448.256836 9535.177734 -9154.302734
+angles=0.000 -90.000 0.000
+model=models/props_lab/keypad.mdl
+[sgu_stuff]
+classname=floorchevron
+position=11263.939453 -9704.975586 576.031250
+angles=0.000 90.009 -0.000
+model=models/the_sniper_9/universe/stargate/floorchevron.mdl
+ematerial=The_Sniper_9/Universe/Stargate/UniverseChevronOff.vmt
+[ramp]
+classname=ramp
+position=-13839.953125 -4987.922363 32.275406
+angles=0.000 44.368 -0.000
+model=models/zsdaniel/ramp/ramp.mdl
+[ramp]
+classname=sgc_ramp
+position=-5983.814453 -4609.833496 548.031250
+angles=0.000 -0.266 0.000
+[ramp]
+classname=icarus_ramp
+position=-3383.043945 3564.240723 441.031250
+angles=0.000 89.608 -0.000
+[ramp]
+classname=future_ramp
+position=2413.541016 4106.612305 145.031250
+angles=0.000 -90.058 0.000

--- a/lua/data/gatespawner_group_maps/gm_freespace_09_extended.lua
+++ b/lua/data/gatespawner_group_maps/gm_freespace_09_extended.lua
@@ -1,0 +1,150 @@
+[gatespawner]
+version = 3 Group
+
+
+[stargate]
+classname=stargate_sg1
+position=9973.107422 -8406.665039 -14044.050781
+angles=0.000 0.256 0.000
+address=SPAWN0
+group=M@
+name=Spawn
+private=false
+locale=false
+[stargate]
+classname=stargate_universe
+position=-6744.700195 2838.228271 -14177.968750
+angles=0.000 -89.701 0.000
+address=WAREHO
+group=U@!
+name=Warehouse
+private=false
+locale=false
+[stargate]
+classname=stargate_tollan
+position=-13243.750977 2623.699707 -13205.968750
+angles=0.000 270.691 0.000
+address=BRIDGE
+group=M@
+name=Bridges area
+private=false
+locale=false
+[stargate]
+classname=stargate_universe
+position=-10741.955078 4464.797363 -14202.968750
+angles=0.000 90.774 0.000
+address=AIRFEL
+group=U@!
+name=Air field
+private=false
+locale=false
+[stargate]
+classname=stargate_atlantis
+position=1014.038147 -13889.685547 -14166.223633
+angles=-0.000 90.077 0.000
+address=SEDTRA
+group=P@
+name=Speed track
+private=false
+locale=false
+[stargate]
+classname=stargate_atlantis
+position=10032.667969 9053.858398 -14187.200195
+angles=0.000 178.678 0.000
+address=LAKEVI
+group=P@
+name=Lake vilage
+private=false
+locale=false
+[stargate]
+classname=stargate_sg1
+position=-3764.184814 5630.815918 -14116.703125
+angles=-0.000 91.558 0.000
+address=FLATN1
+group=M@
+name=Flatlands #1
+private=false
+locale=false
+[stargate]
+classname=stargate_movie
+position=-11369.661133 -7994.544434 -14190.748047
+angles=0.000 90.381 0.000
+address=FLATN2
+group=M@
+name=Flatlands #2
+private=false
+locale=false
+[stargate]
+classname=stargate_sg1
+position=10721.419922 1796.769409 -14245.968750
+angles=0.000 269.413 0.000
+address=GARES0
+group=M@
+name=Garages
+private=false
+locale=false
+[dhd]
+classname=dhd_sg1
+position=10147.596680 -8515.887695 -14121.050781
+angles=15.000 35.256 0.000
+destroyed=false
+[dhd]
+classname=dhd_universe
+position=-6623.131348 2661.939453 -14334.768555
+angles=15.000 -52.903 0.000
+destroyed=false
+[dhd]
+classname=dhd_universe
+position=-10749.898438 5052.744141 -14310.968750
+angles=15.000 -89.226 0.000
+destroyed=false
+[dhd]
+classname=dhd_atlantis
+position=1015.418579 -13350.163086 -14350.768555
+angles=15.000 89.637 0.000
+destroyed=false
+[dhd]
+classname=dhd_atlantis
+position=9654.649414 8867.650391 -14283.528320
+angles=15.000 209.478 0.000
+destroyed=false
+[dhd]
+classname=dhd_sg1
+position=-3902.206055 5829.205078 -14250.381836
+angles=15.000 111.358 0.000
+destroyed=false
+[dhd]
+classname=dhd_sg1
+position=10734.045898 1165.262207 -14350.768555
+angles=15.000 271.613 0.000
+destroyed=false
+[ramp]
+classname=ramp
+position=10157.105469 -8405.843750 -14177.050781
+angles=0.000 0.256 -0.000
+model=models/boba_fett/ramps/ramp10.mdl
+[ramp]
+classname=ramp
+position=1014.038147 -13889.685547 -14256.223633
+angles=0.000 90.077 -0.000
+model=models/boba_fett/ramps/ramp4.mdl
+[ramp]
+classname=ramp
+position=-3764.184814 5630.815918 -14335.703125
+angles=0.000 91.558 -0.000
+model=models/boba_fett/ramps/ramp5.mdl
+[ramp]
+classname=ramp
+position=-11370.092773 -7929.545898 -14335.748047
+angles=0.000 90.381 -0.000
+model=models/boba_fett/ramps/ramp2.mdl
+[ramp]
+classname=ramp_2
+position=-10745.602539 4734.772949 -14340.968750
+angles=0.000 90.774 -0.000
+model=models/iziraider/ramp2/ramp2.mdl
+[ramp]
+classname=sgu_ramp
+position=-6744.219238 2746.029541 -14319.968750
+angles=0.000 -89.701 0.000
+model=models/boba_fett/ramps/sgu_ramp/sgu_ramp_small.mdl

--- a/lua/data/gatespawner_group_maps/gm_freespace_13.lua
+++ b/lua/data/gatespawner_group_maps/gm_freespace_13.lua
@@ -1,0 +1,126 @@
+[gatespawner]
+version = 3 Group
+
+
+[stargate]
+classname=stargate_sg1
+position=-2345.825439 992.299438 -14414.254883
+angles=-0.000 -90.000 0.000
+address=YXJFTN
+group=M@
+name=Spawn
+private=false
+locale=false
+[stargate]
+classname=stargate_universe
+position=736.093201 -0.112466 -14789.968750
+angles=0.000 179.815 0.000
+address=SEHTPV
+group=U@!
+name=Basement
+private=false
+locale=false
+[stargate]
+classname=stargate_atlantis
+position=-13564.216797 -15159.869141 -14758.010742
+angles=0.000 57.082 0.000
+address=K82TMQ
+group=P@
+name=Lake
+private=false
+locale=false
+[stargate]
+classname=stargate_sg1
+position=13628.551758 4972.555664 -14672.616211
+angles=0.000 -44.231 0.000
+address=6XRKN9
+group=M@
+name=Garages
+private=false
+locale=false
+[stargate]
+classname=stargate_sg1
+position=8325.335938 -6263.070801 -15651.968750
+angles=0.000 -0.000 0.000
+address=VB2QY5
+group=M@
+name=Hangar
+private=false
+locale=false
+[stargate]
+classname=stargate_atlantis
+position=-14976.221680 -5055.724121 -15749.968750
+angles=0.000 90.000 0.000
+address=XSJN3Q
+group=P@
+name=Dark room
+private=false
+locale=false
+[stargate]
+classname=stargate_atlantis
+position=-15359.527344 15652.693359 -15694.968750
+angles=0.000 -90.000 0.000
+address=M6ZB08
+group=P@
+name=Underground
+private=false
+locale=false
+[dhd]
+classname=dhd_sg1
+position=-2530.913818 754.836426 -14598.799805
+angles=15.000 -114.072 -0.000
+destroyed=false
+[dhd]
+classname=dhd_universe
+position=712.304932 177.484055 -14894.768555
+angles=15.000 132.675 0.000
+destroyed=false
+[dhd]
+classname=dhd_atlantis
+position=-13579.750000 -14745.793945 -14866.010742
+angles=15.000 80.897 -0.000
+destroyed=false
+[dhd]
+classname=dhd_sg1
+position=13614.059570 4745.201172 -14846.768555
+angles=15.000 287.780 0.000
+destroyed=false
+[dhd]
+classname=dhd_sg1
+position=8694.483398 -6380.641602 -15814.768555
+angles=15.000 -26.471 -0.000
+destroyed=false
+[dhd]
+classname=dhd_atlantis
+position=-14816.047852 -5023.649414 -15854.768555
+angles=15.000 49.912 -0.000
+destroyed=false
+[dhd]
+classname=dhd_atlantis
+position=-15615.554688 15423.743164 -15854.768555
+angles=15.000 242.560 0.000
+destroyed=false
+[sgu_stuff]
+classname=floorchevron
+position=696.093384 0.016601 -14879.968750
+angles=0.000 -0.185 0.000
+model=models/the_sniper_9/universe/stargate/floorchevron.mdl
+ematerial=The_Sniper_9/Universe/Stargate/UniverseChevronOff.vmt
+[ramp]
+classname=ramp
+position=-2345.825439 992.299438 -14504.254883
+angles=-0.000 -90.000 0.000
+model=models/boba_fett/ramps/ramp4.mdl
+[ramp]
+classname=ramp
+position=13655.780273 4946.048828 -14831.616211
+angles=0.000 -44.231 0.000
+model=models/boba_fett/ramps/ramp6.mdl
+[ramp]
+classname=sgc_ramp
+position=8325.335938 -6263.070801 -15651.968750
+angles=0.000 -0.000 0.000
+[ramp]
+classname=future_ramp
+position=-15359.527344 15652.693359 -15694.968750
+angles=0.000 -90.000 0.000

--- a/lua/data/gatespawner_group_maps/gm_genesis.lua
+++ b/lua/data/gatespawner_group_maps/gm_genesis.lua
@@ -1,0 +1,259 @@
+[gatespawner]
+version = 3 Group
+
+
+[stargate]
+classname=stargate_universe
+position=1535.896362 -9632.005859 -8741.968750
+angles=0.000 90.179 -0.000
+address=SPAWN0
+group=U@!
+name=Spawn Room
+private=false
+locale=false
+[stargate]
+classname=stargate_sg1
+position=-8063.797852 -8783.935547 -8037.968750
+angles=0.000 90.135 0.000
+address=CPLEX0
+group=M@
+name=Small Complex
+private=false
+locale=false
+[stargate]
+classname=stargate_atlantis
+position=3465.011963 -37.661499 -8693.968750
+angles=0.000 89.792 0.000
+address=RCTAKE
+group=P@
+name=RC car track
+private=false
+locale=false
+[stargate]
+classname=stargate_sg1
+position=-7003.861328 -4794.130371 -9739.968750
+angles=0.000 -0.408 0.000
+address=C2HANG
+group=M@
+name=C2 Hangar
+private=false
+locale=false
+[stargate]
+classname=stargate_atlantis
+position=-11351.184570 11041.611328 -7534.968750
+angles=0.000 -0.053 0.000
+address=CMLEX1
+group=P@
+name=Corner Complex
+private=false
+locale=false
+[stargate]
+classname=stargate_universe
+position=-104.985123 1485.368042 -12599.311523
+angles=0.000 -90.115 0.000
+address=AVIEWS
+group=U@!
+name=Arena Viewing Stage
+private=false
+locale=false
+[stargate]
+classname=stargate_atlantis
+position=12264.347656 -9474.510742 -8229.968750
+angles=0.000 -179.818 0.000
+address=DOCKS0
+group=P@
+name=Docks
+private=false
+locale=false
+[stargate]
+classname=stargate_atlantis
+position=2501.627686 9577.350586 -9498.968750
+angles=0.000 -89.960 0.000
+address=B2HANG
+group=P@
+name=B2 Hangar
+private=false
+locale=false
+[stargate]
+classname=stargate_tollan
+position=-6292.193359 -7050.694336 -10981.968750
+angles=0.000 89.863 0.000
+address=C2SHAF
+group=M@
+name=C2 Elevator Shaft
+private=true
+locale=false
+[stargate]
+classname=stargate_sg1
+position=1450.933960 -94.891022 -7990.434082
+angles=-0.000 89.895 0.000
+address=SURFAC
+group=M@
+name=Surface Central
+private=false
+locale=false
+[stargate]
+classname=stargate_atlantis
+position=-2142.502197 -3048.567139 9160.463867
+angles=-0.000 88.951 0.000
+address=SKYGAT
+group=P@
+name=Sky Gate
+private=false
+locale=false
+[stargate]
+classname=stargate_sg1
+position=14938.648438 14936.208984 -7966.718750
+angles=-0.000 -134.781 0.000
+address=LOENYC
+group=M@
+name=Lonely Corner
+private=false
+locale=false
+[dhd]
+classname=dhd_universe
+position=1535.928345 -9152.029297 -8846.768555
+angles=15.000 89.123 -0.000
+destroyed=false
+[dhd]
+classname=dhd_sg1
+position=-7999.950195 -8255.791016 -8142.768555
+angles=15.000 -137.790 -0.000
+destroyed=false
+[dhd]
+classname=dhd_city
+position=3133.622559 450.348785 -8783.639648
+angles=-0.069 0.098 -0.009
+[dhd]
+classname=dhd_sg1
+position=-6620.635742 -4679.410645 -9902.768555
+angles=15.000 29.227 0.000
+destroyed=false
+[dhd]
+classname=dhd_atlantis
+position=-10743.731445 10797.205078 -7694.768555
+angles=15.000 359.552 0.000
+destroyed=false
+[dhd]
+classname=dhd_universe
+position=-245.206268 1375.650146 -12697.311523
+angles=15.000 -55.115 0.000
+destroyed=false
+[dhd]
+classname=dhd_atlantis
+position=11808.172852 -9474.634766 -8334.768555
+angles=15.000 179.654 0.000
+destroyed=false
+[dhd]
+classname=dhd_atlantis
+position=2502.042969 8989.350586 -9606.968750
+angles=15.000 90.040 0.000
+destroyed=false
+[dhd]
+classname=dhd_sg1
+position=1446.600830 270.117493 -8150.434082
+angles=15.000 89.895 0.000
+destroyed=false
+[dhd]
+classname=dhd_sg1
+position=14987.320313 14606.498047 -8206.768555
+angles=15.000 -115.575 -0.000
+destroyed=false
+[sgu_stuff]
+classname=bearing
+position=1535.890137 -9630.005859 -8605.968750
+angles=-0.000 90.179 0.000
+model=models/iziraider/gatebearing/bearing.mdl
+[sgu_stuff]
+classname=floorchevron
+position=1535.771484 -9592.005859 -8831.968750
+angles=0.000 -89.821 0.000
+model=models/the_sniper_9/universe/stargate/floorchevron.mdl
+ematerial=The_Sniper_9/Universe/Stargate/UniverseChevronOff.vmt
+[ring_panel]
+classname=ring_panel_goauld
+position=-106.534134 715.869629 -12631.811523
+angles=0.000 89.885 0.000
+[ring_panel]
+classname=ring_panel_goauld
+position=-892.838806 -12146.208008 -14778.717773
+angles=-0.000 90.984 0.000
+[ring_panel]
+classname=ring_panel_ancient
+position=3104.919189 450.100525 -8728.038086
+angles=0.009 2.529 -0.002
+[ring_panel]
+classname=ring_panel_ancient
+position=1727.042114 -8998.427734 -8815.421875
+angles=-0.112 -179.830 -0.446
+[ring_base]
+classname=ring_base_ancient
+position=-106.333832 815.369446 -12681.811523
+angles=0.000 -90.115 0.000
+address=15
+[ring_base]
+classname=ring_base_ancient
+position=-894.496765 -12049.722656 -14824.717773
+angles=0.000 0.984 0.000
+address=21
+[ring_base]
+classname=ring_base_goauld
+position=3351.961914 394.134308 -8448.484375
+angles=0.011 60.432 179.999
+address=12
+[ring_base]
+classname=ring_base_goauld
+position=1536.724609 -9024.423828 -8448.382813
+angles=0.009 -152.222 -179.983
+address=1
+[ramp]
+classname=ramp
+position=-105.790306 1085.368896 -12794.311523
+angles=0.000 -90.115 0.000
+model=models/boba_fett/catwalk_build/hover_ramp.mdl
+[ramp]
+classname=ramp
+position=1451.427246 175.108521 -8161.434082
+angles=0.000 89.895 -0.000
+model=models/iziraider/ramp4/ramp4.mdl
+[ramp]
+classname=ramp
+position=-894.496765 -12049.722656 -14847.717773
+angles=0.000 0.984 -0.000
+model=models/boba_fett/ramps/ring_ramps/ring_ramp.mdl
+[ramp]
+classname=ramp
+position=14891.453125 14888.652344 -8191.718750
+angles=-0.000 -134.781 0.000
+model=models/boba_fett/ramps/ramp3.mdl
+[ramp]
+classname=ramp_2
+position=2501.818359 9307.350586 -9636.968750
+angles=0.000 -89.960 0.000
+model=models/iziraider/ramp2/ramp2.mdl
+[ramp]
+classname=sgc_ramp
+position=-7003.861328 -4794.130371 -9739.968750
+angles=0.000 -0.408 0.000
+[ramp]
+classname=future_ramp
+position=-11351.184570 11041.611328 -7534.968750
+angles=0.000 -0.053 0.000
+[gravitycontroller]
+classname=gravitycontroller
+position=-2142.502197 -3048.566895 9025.463867
+angles=0.000 -1.049 -180.000
+model=models/cebt/sga_pwnode.mdl
+sound=ambient/atmosphere/underground_hall_loop1.wav
+[gravitycontroller]
+classname=gravitycontroller
+position=-2260.482422 -3046.406982 9228.463867
+angles=60.000 178.951 -0.000
+model=models/cebt/sga_pwnode.mdl
+sound=ambient/atmosphere/underground_hall_loop1.wav
+[gravitycontroller]
+classname=gravitycontroller
+position=-2024.521851 -3050.727051 9228.463867
+angles=-60.000 178.951 -0.000
+model=models/cebt/sga_pwnode.mdl
+sound=ambient/atmosphere/underground_hall_loop1.wav

--- a/lua/data/gatespawner_group_maps/gm_neon_construct.lua
+++ b/lua/data/gatespawner_group_maps/gm_neon_construct.lua
@@ -1,0 +1,87 @@
+[gatespawner]
+version = 3 Group
+
+
+[stargate]
+classname=stargate_atlantis
+position=1187.3163 6297.3237 108.2754
+angles=0.000 -90.500 0.000
+address=WATERS
+group=P@
+name=Waterside
+private=false
+locale=false
+[stargate]
+classname=stargate_sg1
+position=-5187.5471 -1479.0598 -53.9688
+angles=0.000 0.800 -0.000
+address=DARKCH
+group=M@
+name=Dark Chamber
+private=false
+locale=false
+[stargate]
+classname=stargate_sg1
+position=-2323.6492 -3028.0210 2938.0313
+angles=0.000 90.340 0.000
+address=SKYCRA
+group=X@
+name=Skyscraper
+private=true
+locale=false
+[dhd]
+classname=dhd_atlantis
+position=1355.3340 6149.3003 -46.7687
+angles=15.000 -52.000 0.000
+destroyed=false
+[dhd]
+classname=dhd_sg1
+position=-5064.1426 -1302.9622 -158.7688
+angles=15.000 20.600 -0.000
+destroyed=false
+[dhd]
+classname=dhd_sg1
+position=-2493.0442 -2871.7432 2832.2312
+angles=15.000 89.020 0.000
+destroyed=false
+[ring_panel]
+classname=ring_panel_goauld
+position=-3232.0000 -1697.2682 98.0313
+angles=0.000 0.580 -0.000
+[ring_panel]
+classname=ring_panel_goauld
+position=908.7753 -1023.5024 -94.4197
+angles=0.000 90.015 -0.294
+[ring_panel]
+classname=ring_panel_goauld
+position=-2063.5735 -2559.7808 -205.9688
+angles=0.000 89.020 -0.000
+[ring_panel]
+classname=ring_panel_goauld
+position=-4944.4834 5356.5210 -53.1502
+angles=0.000 179.560 0.000
+[ring_base]
+classname=ring_base_ancient
+position=908.8730 -916.7200 -143.6183
+angles=0.001 94.437 -0.010
+address=1
+[ring_base]
+classname=ring_base_ancient
+position=-3120.3135 -1701.1188 48.0313
+angles=0.000 91.440 -0.000
+address=3
+[ring_base]
+classname=ring_base_ancient
+position=-2065.1899 -2474.6194 15.6705
+angles=0.003 71.669 -179.998
+address=2
+[ring_base]
+classname=ring_base_ancient
+position=-5048.9189 5357.4272 -95.5047
+angles=0.001 -179.992 -0.003
+address=4
+[ramp]
+classname=ramp
+position=1187.3163 6297.3237 -31.7246
+angles=0.000 -90.500 0.000
+model=models/zsdaniel/ramp/ramp.mdl


### PR DESCRIPTION
added some GateSpawner lua's some for maps like gm_neon_construct which are just reskins of construct and it is just the gm_construct.lua for gatespawners but renamed so that they work. I made one for gm_construct_beta_13 which uses the normal gm_construct.lua but with more stargates and an extra ring and made it so all the stargates can go to each other by setting them all to the Milkyway group. there are also some GateSpawners for some popular maps.