### PR TITLE
Preserve life support suit levels when exiting various entities

### DIFF
--- a/lua/entities/control_chair.lua
+++ b/lua/entities/control_chair.lua
@@ -239,6 +239,8 @@ end
 
 function ENT:DeactivateChair(p)
 
+	
+	local lsSuitData = self.Pilot.suit and {air=self.Pilot.suit.air, coolant=self.Pilot.suit.coolant,energy=self.Pilot.suit.energy} or nil
 	self.Pilot:UnSpectate()
 	self.Pilot:DrawWorldModel(true)
 	self.Pilot:DrawViewModel(true)
@@ -258,6 +260,11 @@ function ENT:DeactivateChair(p)
 	self.Pilot:SetParent()
 	self.Pilot:SetNWBool("Control",false)
 	self.Pilot:SetNWEntity("chair",NULL)
+	if(lsSuitData) then
+		self.Pilot.suit.air = lsSuitData.air
+		self.Pilot.suit.coolant = lsSuitData.coolant
+		self.Pilot.suit.energy = lsSuitData.energy
+	end
 	self:SupplyResource("energy",500)
 --	self.Ragdoll:Remove()
 	self.Controlling=false

--- a/lua/entities/kino_ball.lua
+++ b/lua/entities/kino_ball.lua
@@ -205,11 +205,17 @@ end
 function ENT:ExitKino(ply)
 	if (IsValid(ply)) then
 		if (ply:Alive()) then
+			local lsSuitData = ply.suit and {air=ply.suit.air, coolant=ply.suit.coolant,energy=ply.suit.energy} or nil
 			ply:SetMoveType(MOVETYPE_WALK);
 			ply:SetObserverMode(OBS_MODE_NONE);
 			ply:Spawn();
 			ply:SetFOV(ply.CAP_KINO_FOV or 0,0.3);
 			ply:SetPos(ply.CAP_KINO_StartPos or ply:GetPos() + Vector(0,0,5)); -- whoa it repaired everythin
+			if(lsSuitData) then
+				ply.suit.air = lsSuitData.air
+				ply.suit.coolant = lsSuitData.coolant
+				ply.suit.energy = lsSuitData.energy
+			end
 		end
 		ply:SetViewEntity(ply);
 		ply:SetNWBool("KActive", false);

--- a/lua/entities/puddle_jumper/server/sv_control.lua
+++ b/lua/entities/puddle_jumper/server/sv_control.lua
@@ -3,6 +3,7 @@ function ENT:ExitJumper() --################# Get out the jumper@RononDex
 	if (IsValid(self.Pilot)) then
 		StarGate.KeyBoard.ResetKeys(self.Pilot,"PuddleJumper");
 
+		local lsSuitData = self.Pilot.suit and {air=self.Pilot.suit.air, coolant=self.Pilot.suit.coolant,energy=self.Pilot.suit.energy} or nil
 		self.Pilot:UnSpectate()
 		self.Pilot:DrawViewModel(true)
 		self.Pilot:DrawWorldModel(true)
@@ -20,6 +21,11 @@ function ENT:ExitJumper() --################# Get out the jumper@RononDex
         self.Pilot:SetColor(self.PlayerColor);
 		for k,v in pairs(self.PWeapons) do
 			self.Pilot:Give(tostring(v))
+		end
+		if(lsSuitData) then
+			self.Pilot.suit.air = lsSuitData.air
+			self.Pilot.suit.coolant = lsSuitData.coolant
+			self.Pilot.suit.energy = lsSuitData.energy
 		end
 		self.Pilot = nil;
 	end

--- a/lua/entities/sg_vehicle_base.lua
+++ b/lua/entities/sg_vehicle_base.lua
@@ -155,6 +155,8 @@ function ENT:Exit(kill) --####### Get out @RononDex
 
 	if (IsValid(self.Pilot)) then
 		StarGate.KeyBoard.ResetKeys(self.Pilot,self.Vehicle);
+
+		local lsSuitData = self.Pilot.suit and {air=self.Pilot.suit.air, coolant=self.Pilot.suit.coolant,energy=self.Pilot.suit.energy} or nil
 		self.Pilot:UnSpectate();
 		self.Pilot:DrawViewModel(true);
 		self.Pilot:DrawWorldModel(true);
@@ -164,6 +166,11 @@ function ENT:Exit(kill) --####### Get out @RononDex
 		self.Pilot:SetParent();
 		self.Pilot:SetMoveType(MOVETYPE_WALK);
 		self.Pilot:SetCollisionGroup(COLLISION_GROUP_PLAYER);
+		if(lsSuitData) then
+			self.Pilot.suit.air = lsSuitData.air
+			self.Pilot.suit.coolant = lsSuitData.coolant
+			self.Pilot.suit.energy = lsSuitData.energy
+		end
 	end
 	if(self.ShouldRotorwash) then
 		self:Rotorwash(false);

--- a/lua/entities/sg_vehicle_daedalus/init.lua
+++ b/lua/entities/sg_vehicle_daedalus/init.lua
@@ -787,6 +787,8 @@ function ENT:Exit()
 	self.Active = false;
 	if (not IsValid(self.Driver)) then return end
 	StarGate.KeyBoard.ResetKeys(self.Driver,self.Vehicle);
+
+	local lsSuitData = self.Driver.suit and {air=self.Driver.suit.air, coolant=self.Driver.suit.coolant,energy=self.Driver.suit.energy} or nil
 	self.Driver:UnSpectate();
 	self.Driver:DrawViewModel(true);
 	self.Driver:DrawWorldModel(true);
@@ -794,6 +796,11 @@ function ENT:Exit()
 	self.Driver:Spawn();
 	for k,v in pairs(self.weps) do
 		self.Driver:Give(tostring(v));
+	end
+	if(lsSuitData) then
+		self.Driver.suit.air = lsSuitData.air
+		self.Driver.suit.coolant = lsSuitData.coolant
+		self.Driver.suit.energy = lsSuitData.energy
 	end
 	-- if (self.Entity and self.Entity:IsValid()) then
 		-- self.Driver:SetPos(self.Ring[1]:GetPos()+Vector(0,0,50));

--- a/lua/entities/sg_vehicle_shuttle.lua
+++ b/lua/entities/sg_vehicle_shuttle.lua
@@ -169,6 +169,8 @@ end
 
 function ENT:ExitShut() --################# Get out the jumper@RononDex
 	if (not IsValid(self.Pilot)) then return end
+	
+	local lsSuitData = self.Pilot.suit and {air=self.Pilot.suit.air, coolant=self.Pilot.suit.coolant,energy=self.Pilot.suit.energy} or nil
 	self.Pilot:UnSpectate()
 	self.Pilot:DrawViewModel(true)
 	self.Pilot:DrawWorldModel(true)
@@ -178,6 +180,11 @@ function ENT:ExitShut() --################# Get out the jumper@RononDex
 	--self.Pilot:SetScriptedVehicle(NULL)
 	self.Pilot:SetNetworkedEntity( "ScriptedVehicle", NULL )
 	self.Pilot:SetViewEntity( NULL )
+	if(lsSuitData) then
+		self.Pilot.suit.air = lsSuitData.air
+		self.Pilot.suit.coolant = lsSuitData.coolant
+		self.Pilot.suit.energy = lsSuitData.energy
+	end
 end
 
 

--- a/lua/entities/sg_vehicle_teltac.lua
+++ b/lua/entities/sg_vehicle_teltac.lua
@@ -706,13 +706,14 @@ function ENT:LSSupport()
 			local pos = (p:GetPos()-ent_pos):Length(); -- Where they are in relation to the jumper
 			if(pos<800 and p.suit) then -- If they're close enough
 				if(not(StarGate.RDThree())) then
-					p.suit.air = 100; -- They get air
-					p.suit.energy = 100; -- and energy
-					p.suit.coolant = 100; -- and coolant
+					if (p.suit.air<100) then p.suit.air = 100; end -- They get air
+					if (p.suit.energy<100) then p.suit.energy = 100; end -- and energy
+					if (p.suit.coolant<100) then p.suit.coolant = 100; end -- and coolant
 				else
-					p.suit.air = 200; -- We need double the amount of LS3(No idea why)
-					p.suit.coolant = 200;
-					p.suit.energy = 200;
+					-- We need double the amount of LS3(No idea why)
+					if (p.suit.air<200) then p.suit.air = 200; end -- They get air
+					if (p.suit.energy<200) then p.suit.energy = 200; end -- and energy
+					if (p.suit.coolant<200) then p.suit.coolant = 200; end -- and coolant
 				end
 			end
 		end

--- a/lua/entities/stationary_railgun.lua
+++ b/lua/entities/stationary_railgun.lua
@@ -325,6 +325,7 @@ end
 
 function ENT:Exit()
 	self.Active = false;
+	local lsSuitData = self.Driver.suit and {air=self.Driver.suit.air, coolant=self.Driver.suit.coolant,energy=self.Driver.suit.energy} or nil
 	self.Driver:UnSpectate();
 	self.Driver:DrawViewModel(true);
 	self.Driver:DrawWorldModel(true);
@@ -332,6 +333,11 @@ function ENT:Exit()
 	self.Driver:Spawn();
 	for k,v in pairs(self.weps) do
 		self.Driver:Give(tostring(v));
+	end
+	if(lsSuitData) then
+		self.Driver.suit.air = lsSuitData.air
+		self.Driver.suit.coolant = lsSuitData.coolant
+		self.Driver.suit.energy = lsSuitData.energy
 	end
 	self.Driver:SetPos(self.Stand:GetPos() - self.Stand:GetForward() * 100 - self.Stand:GetRight() * 100);
 	self.Driver:SetParent();

--- a/lua/weapons/kinoremote.lua
+++ b/lua/weapons/kinoremote.lua
@@ -249,6 +249,7 @@ function SWEP:ExitKino()
 	if (IsValid(self.Owner)) then
 		--self.Owner:UnSpectate();
 		if (self.Owner:Alive()) then
+			local lsSuitData = self.Owner.suit and {air=self.Owner.suit.air, coolant=self.Owner.suit.coolant,energy=self.Owner.suit.energy} or nil
 			self.Owner:SetMoveType(MOVETYPE_WALK);
 			self.Owner:SetObserverMode(OBS_MODE_NONE);
 			self.Owner:Spawn();
@@ -256,6 +257,11 @@ function SWEP:ExitKino()
 			self.Owner:SetPos(self.StartPos + Vector(0,0,5)); -- whoa it repaired everythin
 			self.Owner:Give("KinoRemote"); -- We get back our wep
 			self.Owner:SelectWeapon("KinoRemote"); -- Finaly, we can hold our wep :)
+			if(lsSuitData) then
+				self.Owner.suit.air = lsSuitData.air
+				self.Owner.suit.coolant = lsSuitData.coolant
+				self.Owner.suit.energy = lsSuitData.energy
+			end
 		end
 		self.Owner:SetViewEntity(self.Owner);
 		self.Owner:SetNWBool("KActive", false);


### PR DESCRIPTION
When exiting ships and some other entities, CAP essentially respawns the player at the exit position. That makes Spacebuild think the player died, which causes the player's life support suit to reset. This pull request makes affected entities store the life support suit levels prior to respawning the pilot and sets them back to the stored levels afterwards. 

Additionally, commit 49126540dbcc040dfdb2cd83f4b3c31210990f56 makes the Teltak's LSSupport function only set suit values when they're less than what they would be set to. This was already the case with the Puddle Jumper's LSSupport function, but not the Teltak's.