### PR TITLE
Make sure that Rings cannot teleport func_detail and func_brush

### DIFF
--- a/lua/entities/ring_base/init.lua
+++ b/lua/entities/ring_base/init.lua
@@ -9,6 +9,8 @@ local protected_entities = {
 	func_movelinear = true,
 	func_rot_button= true,
 	func_rotating = true,
+	func_detail=true,
+	func_brush=true,
 	prop_door_rotating=true
 	-- ring_* and stargate_* protected too
 }
@@ -366,7 +368,7 @@ function ENT:DoRings()
 	self:Anim(false);
 
 	local dir = 1;
-	-- Addtion by aVoN: Use "FindRange" everytime we are facing down and the angle is below 45° (pi/4)
+	-- Addtion by aVoN: Use "FindRange" everytime we are facing down and the angle is below 45Â° (pi/4)
 	if(self.Entity:GetUp():DotProduct(Vector(0,0,-1)) > 1/math.sqrt(2)) then
 		--self.SetRange = 1024;
 		dir = -1;


### PR DESCRIPTION
For many years I have had an issue with CAP where the rings will teleport large sections of a map for no reason. This fixes it.